### PR TITLE
Index the survey ID for responses and condense JSON output

### DIFF
--- a/web.js
+++ b/web.js
@@ -232,7 +232,7 @@ function ensureStructure(db, callback) {
         collection.ensureIndex('created', done);
       },
       function indexSurvey(done) {
-        // Index the creation date, which we use to sort
+        // Index the survey ID, which we use to look up sets of responses
         collection.ensureIndex('survey', done);
       },
       function indexParcelId(done) {


### PR DESCRIPTION
We look up responses by survey ID, so we need to index that field.

The default express JSON output uses whitespace, which really increases the size of our JSON responses.

/cc @hampelm 
