### PR TITLE
Cache the ETags for parcel responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     , "passport" : "0.1.15"
     , "passport-local" : "0.1.6"
     , "bcrypt" : ">= 0.5"
+    , "lru-cache" : "2.2.2"
   }
   , "devDependencies": {
       "mocha" : "https://github.com/visionmedia/mocha/tarball/master"

--- a/test/test.parcels.js
+++ b/test/test.parcels.js
@@ -204,6 +204,35 @@ suite('Parcels', function () {
         done();
       });
     });
+
+    test('ETag and 304 response', function (done) {
+      // bounding box -122.431640625,37.77288579232438,-122.42889404296875,37.77505678240507
+      // is in San Francisco, so we should find parcels, and the second request
+      // should receive a status code 304 response
+      var url = BASEURL + '/parcels?bbox=-122.431640625,37.77288579232438,-122.42889404296875,37.77505678240507';
+      request({
+        url: url
+      }, function (error, response, body) {
+        should.not.exist(error);
+        response.statusCode.should.equal(200);
+        response.should.be.json;
+
+        var etag = response.headers.etag;
+        request({
+          url: url,
+          headers: {
+            'If-None-Match': etag
+          }
+        }, function (error, response, body) {
+          should.not.exist(error);
+          response.statusCode.should.equal(304);
+          response.headers.etag.should.equal(etag);
+
+          done();
+        });
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
We can send status-304 responses without hitting the database.

/cc @hampelm 
