### PR TITLE
Add response count to survey object

### DIFF
--- a/lib/controllers/surveys.js
+++ b/lib/controllers/surveys.js
@@ -27,11 +27,6 @@ exports.list = function list(req, res) {
 exports.get = function get(req, res) {
   var surveyId = req.params.surveyId;
 
-  var details;
-  if(req.query.details) {
-    details = Response.count({ survey: surveyId });
-  }
-
   Survey.findOne({
     id: surveyId
   })
@@ -41,16 +36,11 @@ exports.get = function get(req, res) {
     if (survey === null) {
       res.send(404);
     } else {
-
-      if(details) {
-        details.exec(function(error, count) {
-          if (util.handleError(error, res)) { return; }
-          survey.responseCount = count;
-          res.send({ survey: survey });
-        });
-      }else {
+      Response.count({ survey: surveyId }).exec(function (error, count) {
+        if (util.handleError(error, res)) { return; }
+        survey.responseCount = count;
         res.send({ survey: survey });
-      }
+      });
     }
   });
 };

--- a/test/test.surveys.js
+++ b/test/test.surveys.js
@@ -336,31 +336,11 @@ suite('Surveys', function () {
         assert.equal(data_two.surveys[0].name, parsed.survey.name, 'Response differs from posted data');
         assert.deepEqual(data_two.surveys[0].paperinfo, parsed.survey.paperinfo, 'Response differs from posted data');
 
-        parsed.survey.should.have.property('slug');
-        parsed.survey.slug.should.be.a('string');
-
-        done();
-      });
-    });
-
-    test('Getting details for a survey', function (done) {
-      request.get({url: BASEURL + '/surveys/' + id + '/?details=true'}, function (error, response, body) {
-        assert.ifError(error);
-        assert.equal(response.statusCode, 200, 'Status should be 200. Status is ' + response.statusCode);
-
-        var parsed = JSON.parse(body);
-
-        assert.ok(parsed.survey, 'Parsed response body should have a property called "survey".');
-
-        assert.equal(parsed.survey.id, id, 'The returned survey should match the requested ID.');
-        assert.equal(data_two.surveys[0].name, parsed.survey.name, 'Response differs from posted data');
-        assert.deepEqual(data_two.surveys[0].paperinfo, parsed.survey.paperinfo, 'Response differs from posted data');
-
-        parsed.survey.should.have.property('slug');
-        parsed.survey.slug.should.be.a('string');
-
         parsed.survey.should.have.property('responseCount');
         parsed.survey.responseCount.should.be.a('number');
+
+        parsed.survey.should.have.property('slug');
+        parsed.survey.slug.should.be.a('string');
 
         done();
       });


### PR DESCRIPTION
I'd like to have the responseCount available in the survey object. It'll make it easier to do things like give a survey overview. I initially tried adding a `?details=true` param to trigger the count, but I don't think that's needed -- it's a fast, indexed query.

Ideally, count would also be available in the list of surveys, along with "most recent response", but I don't know the best way to do that with async queries. Would probably use the `async` lib. 
