### PR TITLE
Fix mongodb timeout setting

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -183,7 +183,7 @@ function run(settings, cb) {
       server: {
         socketOptions: {
           // If we attempt to connect for 45 seconds, stop.
-          timeout: 60,
+          connectTimeoutMS: 45000,
           keepAlive: 1
         }
       }


### PR DESCRIPTION
Thanks to better documentation, we now use the correct setting and scale.
http://mongodb.github.io/node-mongodb-native/contents.html

/cc @hampelm 
