### PR TITLE
Respect object_id, the successor to parcel_id

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -572,6 +572,7 @@ function saveResponses(res, data, surveyId) {
       source: item.source,
       geo_info: item.geo_info,
       parcel_id: item.parcel_id,
+      object_id: item.object_id,
       responses: item.responses
     });
 

--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -71,7 +71,7 @@ responseSchema.set('toObject', {
       },
       files: ret.files,
       parcel_id: ret.parcel_id,
-      object_id: ret.parcel_id,
+      object_id: ret.object_id,
       responses: ret.responses
     };
   }
@@ -154,7 +154,7 @@ responseSchema.pre('save', function setObjectId(next) {
   if (this.parcel_id !== undefined && this.object_id === undefined) {
     this.object_id = this.parcel_id;
   } else if (this.object_id !== undefined && this.parcel_id === undefined) {
-    this.object_id = this.parcel_id;
+    this.parcel_id = this.object_id;
   }
   next();
 });

--- a/test/test.responses.js
+++ b/test/test.responses.js
@@ -82,6 +82,23 @@ suite('Responses', function () {
       });
     });
 
+    test('Posting JSON to /surveys/' + surveyId + '/responses with object_id and no parcel_id', function (done) {
+
+      var data = fixtures.makeResponses(1);
+      delete data.responses[0].parcel_id;
+
+      request.post({url: url, json: data}, function (error, response, body) {
+        should.not.exist(error);
+        response.statusCode.should.equal(201);
+        body.responses[0].should.have.property('object_id');
+        body.responses[0].should.have.property('parcel_id');
+        body.responses[0].object_id.should.equal(data.responses[0].object_id);
+        body.responses[0].parcel_id.should.equal(data.responses[0].object_id);
+
+        done();
+      });
+    });
+
     test('Posting JSON to /surveys/' + surveyId + '/responses without a responses object', function (done) {
 
       var data = fixtures.makeResponses(1);


### PR DESCRIPTION
We can now properly save data using the `object_id` field instead of `parcel_id`. Eventually we'll be able to deprecate the `parcel_id` field, as we planned.

/cc @hampelm 
