### PR TITLE
Avoid fetching too many responses at once

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -23,6 +23,45 @@ var converterBaseUrl = settings.converterBase;
 var exportExpiration = 5 * 60 * 1000; // 5 minutes in milliseconds
 
 /**
+* Fetch all of the responses for a given survey. Grabs the entries in chunks,
+* so we don't run into problems with large data sets.
+* TODO: Very large data sets might take seconds, so we should probably use an
+* export/conversion service like with shapefile export.
+* @param surveyID {String}
+* @param done {Function} callback that accepts an error object and an array of responses
+*/
+function getAllResponses(surveyId, done) {
+  function getChunk(start, responses) {
+    var count = 1000;
+    console.log('Fetching chunk [' + start + ',' + count + ') from survey ' + surveyId);
+
+    var query = Response.find({
+      survey: surveyId
+    });
+
+    // Sort in ascending order of creation, so CSV exports vary only at the
+    // bottom (i.e., they grow from the bottom as we get more responses).
+    query.sort({ created: 'asc' });
+
+    query.skip(start);
+    query.limit(count);
+
+    query.lean().exec(function (error, items) {
+      if (error) {
+        return done(error);
+      }
+
+      // If we didn't get as many items as we asked for, then this is the last chunk.
+      if (items.length < count) {
+        return done(null, responses.concat(items));
+      }
+      getChunk(start + count, responses.concat(items));
+    });
+  }
+  getChunk(0, []);
+}
+
+/**
 * Export a given survey. Includes options to filter and format the results.
 *
 * @method exportResults
@@ -33,16 +72,7 @@ var exportExpiration = 5 * 60 * 1000; // 5 minutes in milliseconds
 * @param writer {Function} Writes a given record to a string
 */
 function exportResults(surveyId, filters, writer) {
-  var query = Response.find({
-    survey: surveyId
-  });
-
-  // Sort in ascending order of creation, so CSV exports vary only at the
-  // bottom (i.e., they grow from the bottom as we get more responses).
-  query.sort({ created: 'asc' });
-
-  query.lean()
-  .exec(function (error, items) {
+  getAllResponses(surveyId, function (error, items) {
     if (error) {
       writer(error);
       return;


### PR DESCRIPTION
We can run into mongodb driver issues if we fetch too many responses all at once. Instead, we get responses in chunks of 1000 for CSV/KML export.

Because large CSV/KML export requests can take a while to serve, we should look into offloading these to an export/conversion service, like with shapefile export.

/cc @hampelm 
