### PR TITLE
Pass the reset info in a URL fragment path

### DIFF
--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -251,7 +251,7 @@ exports.forgotPassword = function forgotPassword(req, response, next) {
       // Generate the email
       var host = req.headers.host;
       var resetText = templates.render('passwordReset', {
-        'link': 'https://' + host + '/reset/' + resetString
+        'link': 'https://' + host + '/#reset/' + resetString
       }, function(error, resetText) {
         var message = {
           to: email,


### PR DESCRIPTION
Use a link for password reset that's compatible with our dashboard URLs.

/cc @hampelm 
