### PR TITLE
Use limited queries for stats computation

### DIFF
--- a/lib/controllers/surveys.js
+++ b/lib/controllers/surveys.js
@@ -87,7 +87,8 @@ exports.stats = function getStats(req, res) {
 
     // Count the answers
     var r = doc.responses;
-    __.each(r, function (val, key) {
+    Object.keys(r).forEach(function (key) {
+      var val = r[key];
       var question = stats[key];
       if (question === undefined) {
         question = stats[key] = {};
@@ -156,7 +157,8 @@ exports.stats = function getStats(req, res) {
     }
 
     // Calculate "no response" count for each question
-    __.each(stats, function (stat, key) {
+    Object.keys(stats).forEach(function (key) {
+      var stat = stats[key];
       var sum = __.reduce(stat, summer, 0);
       var remainder = count - sum;
 


### PR DESCRIPTION
When we streamed responses in, the driver could still receive a batch that was large enough to choke it. To be safe, we limit the number of responses.

Add some other optimizations that likely only kick in for large surveys.

/cc @hampelm 
