### PR TITLE
Fix issue where stats are broken if response object is missing

### DIFF
--- a/lib/controllers/surveys.js
+++ b/lib/controllers/surveys.js
@@ -86,6 +86,9 @@ exports.stats = function getStats(req, res) {
     stats.collectors[key] = val;
 
     // Count the answers
+    if (doc.responses === undefined) {
+      return;
+    }
     var r = doc.responses;
     Object.keys(r).forEach(function (key) {
       var val = r[key];


### PR DESCRIPTION
We can't assume `doc.responses` exists. 
