### PR TITLE
Add a tool for storing backups on S3

### DIFF
--- a/maintenance/store-backup.js
+++ b/maintenance/store-backup.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/*jslint node: true */
+'use strict';
+
+/*
+ * Store Heroku Postgresql backups to our S3 account, so we can keep them
+ * forever and ever.
+ * Run as a one-off dyno on Heroku:
+ *   heroku run maintenance/store-backup.js BUCKET OPTIONAL-FILENAME-FRIENDLY-COMMENT \"`heroku pgbackups:url b005`\"
+ *
+ *   heroku run maintenance/store-backup.js localdata-backup lighting-experimentation-prashant \"`heroku pgbackups:url b001`\"
+ *   heroku run maintenance/store-backup.js localdata-backup \"`heroku pgbackups:url b001 --app localdata-beta`\" --app ld-prashant-dev
+ *
+ * The file is stored in the bucket as something like /heroku-pg/2013-11-15T01:27:53.000Z-comment.dump
+ */
+
+var knox = require('knox');
+var request = require('request');
+
+var settings = require('../settings');
+
+var bucket = process.argv[2];
+var comment;
+var herokuUrl;
+
+if (process.argv.length > 4) {
+  comment = process.argv[3];
+  herokuUrl = process.argv[4];
+} else {
+  herokuUrl = process.argv[3];
+}
+
+var prefix = '/heroku-pg/';
+
+var client = knox.createClient({
+  key: settings.aws_key,
+  secret: settings.aws_secret,
+  bucket: bucket
+});
+
+console.log('Transferring Heroku postgresql backup from: ' + herokuUrl);
+
+// Request the dump data from Heroku's temporary URL (an S3 URL with temporary
+// authorization through query string parameters)
+var herokuRequest = request.get(herokuUrl);
+herokuRequest.on('response', function (response) {
+  // Grab the timestamp of the dump from the Last-Modified header.
+  var ts = (new Date(response.headers['last-modified'])).toISOString();
+
+  var name = prefix + ts;
+  if (comment !== undefined) {
+    name += '-' + comment;
+  }
+  name += '.dump';
+
+  console.log('Transferring to bucket: ' + bucket + ', path: ' + name);
+  // Stream the data to our S3 bucket
+  var uploadRequest = client.putStream(response, name, {
+    'Content-Length': response.headers['content-length'],
+    'Content-Type': response.headers['content-type']
+  }, function (error, res) {
+    if (error) {
+      console.log('Error sending the response to S3:');
+      console.log(error);
+      return;
+    }
+
+    console.log('Got status code ' + res.statusCode);
+    // Pipe the S3 response body to stdout
+    res.pipe(process.stdout);
+  });
+
+  var progress = 0;
+  uploadRequest.on('progress', function (data) {
+    var percent = Math.floor(data.percent);
+    if (percent > progress) {
+      progress = percent;
+      process.stdout.write('\r' + percent + '%');
+    }
+  });
+
+});
+
+herokuRequest.end();
+
+herokuRequest.on('error', function (error) {
+  console.log('Error requesting data from the Heroku URL:');
+  console.log(error);
+});


### PR DESCRIPTION
By running this tool through Heroku, we can efficiently transfer backups to our own permanent S3 storage. We can be much more comfortable created a new backup before and after a data import procedure without worrying about the backups we're evicting from Heroku's storage.

After the merge, I'll add specific instructions for our geodata backups to the relevant docs.

/cc @hampelm
