### PR TITLE
Fix some pesky geometries that are invalid for mongo indexing

### DIFF
--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -217,8 +217,9 @@ function simplifyLineString(coordinates) {
   var len = coordinates.length;
   var newCoords = [coordinates[0]];
   for (i = 1; i < len; i += 1) {
-    if (coordinates[i][0] !== coordinates[i-1][0] &&
-        coordinates[i][1] !== coordinates[i-1][1]) {
+    var last = newCoords[newCoords.length - 1];
+    if (coordinates[i][0] !== last[0] &&
+        coordinates[i][1] !== last[1]) {
       newCoords.push(coordinates[i]);
     }
   }
@@ -237,8 +238,8 @@ function createIndexedGeometry(geometry) {
     geom.coordinates = geom.coordinates.slice(0,1);
     if (!sweepline.isSimplePolygon(geom)) {
       geom = util.simplifyCoordinates(geom, 1E-5);
-      geom.coordinates = [simplifyLineString(geom.coordinates[0])];
     }
+    geom.coordinates = [simplifyLineString(geom.coordinates[0])];
   }
   return geom;
 }


### PR DESCRIPTION
Geometries could have repeated coordinates whether or not we apply the simplification algorithm.

With this tweak, the migration created indexable geometries for all but one response.

/cc @hampelm 
