### PR TITLE
SWOP hotfix

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -664,6 +664,48 @@ function saveResponses(res, data, surveyId) {
       object_id = item.parcel_id;
     }
 
+
+    // SWOP HOTFIX
+    // Intended to fix one overlapping parcel
+    if(surveyId === '06a311f0-4b1a-11e3-aca4-1bb74719513f' &&
+      object_id === '865961') {
+
+      console.log("FIXING A GEOMETRY", item.geo_info.geometry);
+
+      item.geo_info.geometry.coordinates = [[
+          [
+            [
+              -87.70179480314255,
+              41.778884812741445
+            ],
+            [
+              -87.70179480314254,
+              41.77865879187205
+            ],
+            [
+              -87.7016633749008,
+              41.77866479243637
+            ],
+            [
+              -87.7016633749007,
+              41.778698795623754
+            ],
+            [
+              -87.70161241292953,
+              41.77870279599755
+            ],
+            [
+              -87.70162850618362,
+              41.778884812741444
+            ],
+            [
+              -87.70179480314255,
+              41.778884812741445
+            ]
+          ]
+        ]];
+    }
+
     var response = new Response({
       properties: {
         survey: surveyId,


### PR DESCRIPTION
Fixes an issue where a self-overlapping building in Chicago cannot be saved by Mongo. 

Note that the bigger issue is #186 & #187; this is just a stopgap. 
