### PR TITLE
Add info fields to the export

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -139,6 +139,35 @@ function exportResults(surveyId, filters, writer) {
         items[i].properties.centroid[0] + ',' + items[i].properties.centroid[1]
       ];
 
+      // Add info subfields
+      var info = items[i].properties.info;
+      var key;
+      for (key in info) {
+        if (info.hasOwnProperty(key)) {
+          if (!headerIndices.hasOwnProperty(key)) {
+            headerIndices[key] = headers.length;
+            maxEltsInCell[key] = 1;
+            headers.push(key);
+            // Add an empty entry to each existing row, since they didn't
+            // have this column.
+            for (j = 0; j < rows.length; j += 1) {
+              rows[j].push('');
+            }
+          }
+
+          var data = info[key];
+          // Check if we have multiple answers.
+          if (util.isArray(data)) {
+            if (data.length > maxEltsInCell[key]) {
+              maxEltsInCell[key] = data.length;
+            }
+          }
+
+          // Add the response to the CSV row.
+          row[headerIndices[key]] = data;
+        }
+      }
+
       // Then, add the survey results
       var resp;
       var responses = items[i].properties.responses;


### PR DESCRIPTION
If there is a `properties.info` subdocument in a Response doc, then we should add those fields to the CSV export. This will all be moved to a background worker system soon.

/cc @hampelm 
