### PR TITLE
Password reset needs to send empty json object on success

### DIFF
--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -259,7 +259,7 @@ exports.forgotPassword = function forgotPassword(req, response, next) {
           if(error){
             return next(error);
           }
-          response.send(200);
+          response.send(200, {});
         });
       });
     });


### PR DESCRIPTION
We need to send an empty json object with our 200 requests because the client expects json
