### PR TITLE
Support geoObjectSource in survey object

### DIFF
--- a/lib/models/Survey.js
+++ b/lib/models/Survey.js
@@ -28,6 +28,22 @@ var surveySchema = new mongoose.Schema({
   // Optional description of the survey
   description: String,
 
+  // Optional object describing the data source
+  // For ArcGIS connections:
+  // "type": "ArcGIS Server",
+  // "endpoint": "http://arcgis...",
+  // "name": [
+  //     "HouseNumber",
+  //     "PrefixDirectional",
+  //     "StreetName"
+  // ],
+  // "id": "parcelIDField"
+  //
+  //  For the features endpoint:
+  //   "type": "LocalData",
+  //   "source": "/api/features?source=detroit-streetlights&bbox={{bbox}}"
+  geoObjectSource: Object,
+
   // Optional number of milliseconds responses are good for
   // Responses older than this date may be considered stale by clients
   responseLongevity: Number,
@@ -91,6 +107,7 @@ surveySchema.set('toObject', {
       tilelayer: ret.tilelayer,
       description: ret.description,
       responseLongevity: ret.responseLongevity,
+      geoObjectSource: ret.geoObjectSource,
       paperinfo: ret.paperinfo,
       zones: ret.zones
     };

--- a/test/surveys.js
+++ b/test/surveys.js
@@ -38,7 +38,10 @@ suite('Surveys', function () {
       "users": ["2"],
       "type": "pointandparcel",
       "errantStuff": 12345,
-      "responseLongevity": 5
+      "responseLongevity": 5,
+      "geoObjectSource": {
+        "type": "foo"
+      }
     } ]
   };
 
@@ -169,6 +172,12 @@ suite('Surveys', function () {
           assert.equal(data_two.surveys[i].location, body.surveys[i].location, 'Response differs from posted data');
           assert.equal(data_two.surveys[i].type, body.surveys[i].type);
           assert.equal(data_two.surveys[i].responseLongevity, body.surveys[i].responseLongevity);
+
+          assert.deepEqual(data_two.surveys[i].geoObjectSource, body.surveys[i].geoObjectSource);
+          if(data_two.surveys[i].geoObjectSource) {
+            assert.equal(data_two.surveys[i].geoObjectSource.type, body.surveys[i].geoObjectSource.type);
+          }
+
           assert.notEqual(data_two.surveys[i].errantStuff, body.surveys[i].errantStuff);
 
           body.surveys[i].should.have.property('created');


### PR DESCRIPTION
We currently delete it when we save the survey. Fixes #375
