### PR TITLE
Use promises to support parallel db calls

### DIFF
--- a/lib/controllers/surveys.js
+++ b/lib/controllers/surveys.js
@@ -3,6 +3,7 @@
 
 var __ = require('lodash');
 var async = require('async');
+var Promise = require('bluebird');
 
 var Response = require('../models/Response');
 var Survey = require('../models/Survey');
@@ -32,29 +33,33 @@ exports.get = function get(req, res) {
   var surveyId = req.params.surveyId;
   var survey;
 
-  // TODO: We can get the count and bounds in parallel and maybe even roll them
-  // into one aggregation pipeline.
-  async.waterfall([
-    function (next) {
-      Survey.findOne({ id: surveyId }).lean().exec(next);
-    },
-    function (result, next) {
-      if (!result) {
-        res.send(404);
-        return;
-      }
-      survey = result;
-      Response.countEntries({ 'properties.survey': surveyId }, next);
-    },
-    function (count, next) {
-      survey.responseCount = count;
-      Response.getBounds(surveyId, next);
-    }
-  ], function (error, bounds) {
-    if (util.handleError(error, res)) { return; }
+  var countPromise = Promise.promisify(Response.countEntries, Response)({
+    'properties.survey': surveyId
+  }).cancellable();
 
-    survey.responseBounds = bounds;
-    res.send({ survey: survey });
+  var boundsPromise = Promise.promisify(Response.getBounds, Response)(surveyId).cancellable();
+
+  Promise.resolve(Survey.findOne({ id: surveyId }).lean().exec())
+  .then(function (survey) {
+    if (!survey) {
+      // Cancel the count and bounds promises.
+      countPromise.cancel();
+      boundsPromise.cancel();
+      return Promise.join(countPromise, boundsPromise)
+      .catch(function (CancellationError, e) {
+        res.send(404);
+      });
+    }
+
+    return Promise.join(countPromise, boundsPromise, function (count, bounds) {
+      survey.responseCount = count;
+      survey.responseBounds = bounds;
+      res.send({ survey: survey });
+    });
+  }).catch(function (error) {
+    console.log(error);
+    console.log(error.stack);
+    res.send(500);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "async": ">=0.2",
     "bcrypt": ">= 0.5",
+    "bluebird": "^2.3.2",
     "connect-mongo": "~0.3.2",
     "connect-s3": "~0.2.0",
     "ejs": "~0.8.3",


### PR DESCRIPTION
Get the response count, response bounds, and survey data at the same time. If there is no such survey (404), we cancel the other two requests.

Super unscientific testing showed a ~30% savings for getting the survey data for a large data set (50k+ entries).

Bluebird promises also seem to perform well again async, and for some patterns they make things much simpler, so this will set us up to use them as needed later.
http://spion.github.io/posts/why-i-am-switching-to-promises.html

/cc @hampelm 
