### PR TITLE
metadata.requested should be compared against exportRequestDuration

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -988,7 +988,7 @@ function handleExport(req, res, type) {
     var metadata = doc.exports[type];
 
     // See when we kicked off the export. If it was a long time ago, then we need to kick off a background task.
-    if (metadata.requested < now - exportDuration) {
+    if (metadata.requested < now - exportRequestDuration) {
       console.log(util.format('info at=export event=generate reason=stale_metadata request_time=%d now=%d export_duration=%d', metadata.requested, now, exportDuration));
       generate();
       return;
@@ -1021,6 +1021,7 @@ function handleExport(req, res, type) {
 
       var lastModifiedText = head.headers['last-modified'];
       var lastModified = new Date(lastModifiedText);
+
       // If the file exists and is old, kick off a background task.
       if (!lastModifiedText || lastModified < now - exportDuration || lastModified < metadata.requested) {
         console.log(util.format('info at=export event=generate reason=stale_export export_time=%d now=%d export_duration=%d', lastModified, now, exportDuration));


### PR DESCRIPTION
Not the source of my problems, but I think that metadata.requested should be compared against `exportRequestDuration` instead of `exportDuration`. `exportDuration` is used for aging out files.  
