### PR TITLE
Optionally log info when requests are received

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -29,6 +29,14 @@ var db = null;
 // ID generator
 var idgen = uuid.v1;
 
+// Log some information when requests are first received.
+if (process.env.REQUEST_LOGGER) {
+  app.use(express.logger({
+    immediate: true,
+    format: process.env.REQUEST_LOGGER
+  }));
+}
+
 // Specify logging through an environment variable, so we can log differently
 // locally, on dev/test Heroku apps, and on production Heroku apps.
 if (process.env.EXPRESS_LOGGER) {

--- a/sample.env
+++ b/sample.env
@@ -43,6 +43,11 @@ TILESERVER_BASE="http://tiles.foo-bar.com"
 # Web server
 TEST_SECURE_PORT=3838
 
+# Log format (optional)
+EXPRESS_LOGGER=':method :url HTTP/:http-version :status :res[content-length] :response-time ms - :remote-addr ":referrer" ":user-agent"'
+# Log format when we receive requests (optional)
+REQUEST_LOGGER='info at=server event=request id=:req[x-request-id] method=:method url=":url" user_agent=":user-agent" length=:req[content-length] type=":req[content-type]" fwd=:req[x-forwarded-for]'
+
 NEW_RELIC_LICENSE_KEY="foobar"
 NEW_RELIC_LOG=stdout
 NEW_RELIC_LOG_LEVEL=info


### PR DESCRIPTION
Log some info when requests are first received, so we don't miss out on things like user-agent and IP address with timeout errors.

/cc @hampelm 
