### PR TITLE
Use group aggregation for stats

### DIFF
--- a/lib/controllers/surveys.js
+++ b/lib/controllers/surveys.js
@@ -205,11 +205,6 @@ exports.removeUser = function addUser(req, res) {
  * https://localhost:3001/api/surveys/123/stats?before=date
  */
 exports.stats = function getStats(req, res) {
-  var stats = {
-    Collectors: {}
-  };
-  var count = 0;
-
   var surveyId = req.params.surveyId;
   var intersects = req.query.intersects;
   var after = req.query.after;
@@ -219,60 +214,9 @@ exports.stats = function getStats(req, res) {
     return memo + num;
   }
 
-  function handleDoc(doc) {
-    var key,
-        val;
-
-    count += 1;
-
-    var index = doc.entries.length - 1;
-    var entry = doc.entries[index];
-
-    // If the latest entry has no responses, then find the most recent entry
-    // that has data.
-    while (!entry.responses) {
-      index -= 1;
-      // If there are no responses at all, then we do nothing with this doc.
-      if (index < 0) {
-        return;
-      }
-      entry = doc.entries[index];
-    }
-
-    // Record the collector
-    key = entry.source.collector;
-    val = stats.Collectors[key];
-    if (val !== undefined) {
-      val += 1;
-    } else {
-      val = 1;
-    }
-    stats.Collectors[key] = val;
-
-    // Count the answers
-    var r = entry.responses;
-    Object.keys(r).forEach(function (key) {
-      var val = r[key];
-      var question = stats[key];
-      if (question === undefined) {
-        question = stats[key] = {};
-        question[val] = 1;
-      } else {
-        var tally = question[val];
-        if (tally === undefined) {
-          tally = 1;
-        } else {
-          tally += 1;
-        }
-        question[val] = tally;
-      }
-    });
-  }
-
   var conditions = {
     'properties.survey': surveyId
   };
-
 
   // Date filters
   if (until || after) {
@@ -289,8 +233,6 @@ exports.stats = function getStats(req, res) {
     }
   }
 
-  console.log("Conditions", conditions);
-
   // Decode any geospatial limits
   if (intersects !== undefined) {
     decodeURIComponent(intersects);
@@ -303,72 +245,105 @@ exports.stats = function getStats(req, res) {
     };
   }
 
-  function getChunk(start, done) {
-    var length = 5000;
-    Response.find(conditions, 'entries')
-    .skip(start).limit(length)
-    .lean()
-    .exec(function (error, chunk) {
+  Response.collection.group(
+    {},
+    conditions,
+    { stats: { Collectors: {} }, count: 0 },
+    function reduce (doc, memo) {
+      var key,
+          val;
+       var stats = memo.stats;
+
+      memo.count += 1;
+
+      var index = doc.entries.length - 1;
+      var entry = doc.entries[index];
+
+      // If the latest entry has no responses, then find the most recent entry
+      // that has data.
+      while (!entry.responses) {
+        index -= 1;
+        // If there are no responses at all, then we do nothing with this doc.
+        if (index < 0) {
+          return;
+        }
+        entry = doc.entries[index];
+      }
+
+      // Record the collector
+      key = entry.source.collector;
+      val = stats.Collectors[key];
+      if (val !== undefined) {
+        val += 1;
+      } else {
+        val = 1;
+      }
+      stats.Collectors[key] = val;
+
+      // Count the answers
+      var r = entry.responses;
+      var keys = Object.keys(r);
+      var i;
+      var len;
+      for (i = 0, len = keys.length; i < len; i += 1) {
+        key = keys[i];
+        val = r[key];
+        var question = stats[key];
+        if (question === undefined) {
+          question = stats[key] = {};
+          question[val] = 1;
+        } else {
+          var tally = question[val];
+          if (tally === undefined) {
+            tally = 1;
+          } else {
+            tally += 1;
+          }
+          question[val] = tally;
+        }
+      }
+    }, function (error, doc) {
       if (error) {
-        done(error);
+        console.log(error);
+        res.send(500);
         return;
       }
 
-      var i;
-      for (i = 0; i < chunk.length; i += 1) {
-        handleDoc(chunk[i]);
+      if (!doc || doc.length === 0) {
+        // Make sure the survey exists. We don't check beforehand because it
+        // saves a query in the most common case.
+        Survey.findOne({
+          id: surveyId
+        })
+        .lean()
+        .exec(function (error, survey) {
+          if (util.handleError(error, res)) { return; }
+          if (survey === null) {
+            res.send(404);
+          } else {
+            res.send({
+              stats: { Collectors: {} }
+            });
+          }
+        });
+        return;
       }
-
-      if (chunk.length === length) {
-        getChunk(start + length, done);
-      } else {
-        done(null);
-      }
-    });
-  }
-
-  getChunk(0, function (error) {
-    if (error) {
-      console.log(error);
-      console.log(error.stack);
-      res.send(500);
-      return;
-    }
-
-    if (count === 0) {
-      // Make sure the survey exists. We don't check beforehand because it
-      // saves a query in the most common case.
-      Survey.findOne({
-        id: surveyId
-      })
-      .lean()
-      .exec(function (error, survey) {
-        if (util.handleError(error, res)) { return; }
-        if (survey === null) {
-          res.send(404);
-        } else {
-          res.send({
-            stats: stats
-          });
-        }
+        
+      var stats = doc[0].stats;
+      var count = doc[0].count;
+      // Calculate "no response" count for each question
+      __.forEach(__.keys(stats), function (key) {
+        var stat = stats[key];
+        var sum = __.reduce(stat, summer, 0);
+        var remainder = count - sum;
+    
+        stats[key]['no response'] = remainder;
       });
-      return;
-    }
-
-    // Calculate "no response" count for each question
-    Object.keys(stats).forEach(function (key) {
-      var stat = stats[key];
-      var sum = __.reduce(stat, summer, 0);
-      var remainder = count - sum;
-
-      stats[key]['no response'] = remainder;
+    
+      res.send({
+        stats: stats
+      });
     });
-
-    res.send({
-      stats: stats
-    });
-
-  });
 };
 
 exports.post = function post(req, response) {

--- a/test/surveys.js
+++ b/test/surveys.js
@@ -3,10 +3,11 @@
 'use strict';
 
 var assert = require('assert');
+var async = require('async');
+var Promise = require('bluebird');
 var request = require('request');
 var should = require('should');
 var util = require('util');
-var async = require('async');
 
 var Survey = require('../lib/models/Survey');
 
@@ -16,6 +17,8 @@ var settings = require('../settings');
 
 
 var BASEURL = 'http://localhost:' + settings.port + '/api';
+
+Promise.promisifyAll(request);
 
 suite('Surveys', function () {
 
@@ -651,6 +654,15 @@ suite('Surveys', function () {
       });
 
     }); // end getting stats outside bbox
+
+    test('stats for a nonexistant survey', function () {
+      return request.getAsync({
+        url: BASEURL + '/surveys/doesnotexist/stats',
+        jar: false
+      }).spread(function (response, body) {
+        response.statusCode.should.equal(404);
+      });
+    });
 
   });
 


### PR DESCRIPTION
The stats calculation is essentially a reduce job with no need for a map step. Since we're not using sharding, and since the output will be well under the 16 MB limit, we can use the `group` operation. We avoid transferring the entire data set to the server, and we avoid the map-reduce performance penalty. Compared to the previous stats implementation, we take 25% (up to possibly 50%) less time for surveys with tens of thousands of entries.
