### PR TITLE
Use cache-control:must-revalidate for most GET requests

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -25,31 +25,37 @@ function enforceHTTPS(req, res, next) {
   next();
 }
 
+function mustRevalidate(req, res, next) {
+  // Clients must revalidate queries responses:
+  res.set('Cache-Control', 'max-age=0, must-revalidate');
+  return next();
+}
+
 exports.setup = function setup(app) {
   var session = app.get('session-middleware');
 
   // Surveys
-  app.get('/api/surveys', session, users.ensureAuthenticated, surveys.list);
-  app.get('/api/surveys/:surveyId', surveys.get);
+  app.get('/api/surveys', session, users.ensureAuthenticated, mustRevalidate, surveys.list);
+  app.get('/api/surveys/:surveyId', mustRevalidate, surveys.get);
   app.post('/api/surveys', session, users.ensureAuthenticated, surveys.post);
   app.put('/api/surveys/:surveyId', session, users.ensureAuthenticated, users.ensureSurveyAccess, surveys.put);
   app.get('/api/slugs/:slug', surveys.getSlug);
 
   // Survey users
-  app.get('/api/surveys/:surveyId/users', session, users.ensureAuthenticated, users.ensureSurveyAccess, surveys.users);
+  app.get('/api/surveys/:surveyId/users', session, users.ensureAuthenticated, users.ensureSurveyAccess, mustRevalidate, surveys.users);
   app.put('/api/surveys/:surveyId/users/:email', session, users.ensureAuthenticated, users.ensureSurveyAccess, surveys.addUser);
   app.del('/api/surveys/:surveyId/users/:email', session, users.ensureAuthenticated, users.ensureSurveyAccess, surveys.removeUser);
 
   // Stats
-  app.get('/api/surveys/:surveyId/stats', stats.stats);
-  app.get('/api/surveys/:surveyId/stats/activity', stats.activity);
-  app.get('/api/surveys/:surveyId/stats/activity/:range', stats.byRange);
+  app.get('/api/surveys/:surveyId/stats', mustRevalidate, stats.stats);
+  app.get('/api/surveys/:surveyId/stats/activity', mustRevalidate, stats.activity);
+  app.get('/api/surveys/:surveyId/stats/activity/:range', mustRevalidate, stats.byRange);
 
   // Responses
-  app.get('/api/surveys/:surveyId/responses', responses.list);
-  app.get('/api/surveys/:surveyId/responses.geojson', formatHelper('geojson'), responses.list);
-  app.get('/api/surveys/:surveyId/responses/:responseId', responses.get);
-  app.patch('/api/surveys/:surveyId/responses/:responseId', session, users.ensureAuthenticated, users.ensureSurveyAccess, responses.patch);
+  app.get('/api/surveys/:surveyId/responses', mustRevalidate, responses.list);
+  app.get('/api/surveys/:surveyId/responses.geojson', mustRevalidate, formatHelper('geojson'), responses.list);
+  app.get('/api/surveys/:surveyId/responses/:responseId', mustRevalidate, responses.get);
+  app.patch('/api/surveys/:surveyId/responses/:responseId', session, users.ensureAuthenticated, users.ensureSurveyAccess, mustRevalidate, responses.patch);
   app.post('/api/surveys/:surveyId/responses', responses.post);
   app.del('/api/surveys/:surveyId/responses/:responseId', session, users.ensureAuthenticated, users.ensureSurveyAccess, responses.del);
   app.post('/api/surveys/:surveyId/responses', responses.post);
@@ -58,13 +64,13 @@ exports.setup = function setup(app) {
   app.get('/api/surveys/:surveyId/responses.zip', session, responses.handleShapefile);
 
   // Forms
-  app.get('/api/surveys/:surveyId/forms', forms.list);
-  app.get('/api/surveys/:surveyId/forms/:formId', forms.get);
+  app.get('/api/surveys/:surveyId/forms', mustRevalidate, forms.list);
+  app.get('/api/surveys/:surveyId/forms/:formId', mustRevalidate, forms.get);
   app.post('/api/surveys/:surveyId/forms', session, users.ensureAuthenticated, users.ensureSurveyAccess,  forms.post);
   app.put('/api/surveys/:surveyId/forms/:formId', session, users.ensureAuthenticated, users.ensureSurveyAccess, forms.put);
 
   // Users
-  app.get('/api/user', session, users.ensureAuthenticated, users.get);
+  app.get('/api/user', session, users.ensureAuthenticated, mustRevalidate, users.get);
   app.post('/api/user', session, enforceHTTPS, users.post);
   app.post('/api/login', session, enforceHTTPS, users.login);
   app.get('/logout', session, users.logout);


### PR DESCRIPTION
Solves a lot of problems with Internet Explorer. 