### PR TITLE
Proxy POST requests to the tileserver properly

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -99,6 +99,31 @@ function textParser(req, res, next) {
   });
 }
 
+function rawParser(req, res, next) {
+  if (req._body) { return next(); }
+  req.body = req.body || {};
+
+  // For GET/HEAD, there's no body to parse.
+  if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
+
+  // Flag as parsed
+  req._body = true;
+
+  var bufs = [];
+  var len = 0;
+  req.on('data', function(chunk){
+    bufs.push(chunk);
+    len += chunk.length;
+  });
+  req.on('end', function(){
+    req.body = Buffer.concat(bufs, len);
+    next();
+  });
+}
+
+// Skip parsing the body for requests that we'll proxy to the tileserver
+app.use('/tiles', rawParser);
+
 // Actually have Express parse text/plain as JSON
 app.use(textParser);
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bcrypt": ">= 0.5",
     "bluebird": "^2.3.2",
     "connect-mongo": "~0.3.2",
-    "connect-s3": "~0.2.0",
+    "connect-s3": "~0.3.0",
     "cuid": "^1.2.4",
     "ejs": "~0.8.3",
     "express": "3.0.x",


### PR DESCRIPTION
Use relevant version of connect-s3, and avoid parsing request bodies for fileserver requests.