### PR TITLE
Use a MongoDB connection string

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -28,12 +28,7 @@ exports.connect = function connect(done) {
     }
   };
 
-  if (settings.mongo_user !== undefined) {
-    opts.user = settings.mongo_user;
-    opts.pass = settings.mongo_password;
-  }
-
-  mongoose.connect(settings.mongo_host, settings.mongo_db, settings.mongo_port, opts);
+  mongoose.connect(settings.mongo, opts);
 
   db = mongoose.connection;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -169,8 +169,7 @@ function setupAuth(db) {
   var expressSession = express.session({
     secret: settings.secret,
     store: new MongoStore({
-      db: settings.mongo_db,
-      mongoose_connection: db,
+      mongooseConnection: db,
       maxAge: 300000
       // collection: 'sessions' [default]
     })
@@ -246,13 +245,8 @@ function run(cb) {
       db.removeAllListeners();
     }
 
-    console.log(_.template('info at=server event=starting port=${port} mongo_host=${mongo_host} mongo_port=${mongo_port} mongo_db=${mongo_db} mongo_user=${mongo_user} pg="${pg}"', {
+    console.log(_.template('info at=server event=starting port=${port}', {
       port: settings.port,
-      mongo_host: settings.mongo_host,
-      mongo_port: settings.mongo_port,
-      mongo_db: settings.mongo_db,
-      mongo_user: settings.mongo_user,
-      pg: settings.psqlConnectionString
     }));
 
     if (!cb) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async": ">=0.2",
     "bcrypt": ">= 0.5",
     "bluebird": "^2.3.2",
-    "connect-mongo": "~0.3.2",
+    "connect-mongo": "~0.6.0",
     "connect-s3": "~0.3.0",
     "cuid": "^1.2.4",
     "ejs": "~0.8.3",

--- a/sample.env
+++ b/sample.env
@@ -5,9 +5,7 @@ SECRET="BLAH"
 TEST_EMAIL="foo@foo-bar.com"
 
 # MongoDB settings
-MONGO_HOST="localhost"
-MONGO_PORT="27017"
-MONGO_DB="scratchdb"
+MONGO="mongodb://localhost:27017/scratchdb"
 MONGO_NATIVE_PARSER="true"
 
 # AWS

--- a/settings.js
+++ b/settings.js
@@ -14,12 +14,7 @@ settings.email.from = 'LocalData <support@localdata.com>';
 settings.email.to = process.env.TEST_EMAIL || 'LocalData <support@localdata.com>'; // Send test emails to your address!
 
 // MongoDB
-settings.mongo_host = process.env.MONGO_HOST || 'localhost';
-settings.mongo_port = parseInt(process.env.MONGO_PORT, 10);
-if (isNaN(settings.mongo_port)) { settings.mongo_port = 27017; }
-settings.mongo_db = process.env.MONGO_DB || 'scratchdb';
-settings.mongo_user = process.env.MONGO_USER;
-settings.mongo_password = process.env.MONGO_PASSWORD;
+settings.mongo = process.env.MONGO;
 settings.mongo_native_parser = false;
 if (process.env.MONGO_NATIVE_PARSER !== undefined && process.env.MONGO_NATIVE_PARSER.toLowerCase() === 'true') {
   settings.mongo_native_parser = true;


### PR DESCRIPTION
We need to use a connection string to specify the replica set, so we can actually react to a switch in primary. This also makes the config values more consistent with the tileserver.

Requires environment variable changes when we deploy.