### PR TITLE
Cache stats calculations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MOCHA = "./node_modules/.bin/mocha"
 
-MOCHA_FLAGS = --ui tdd --reporter spec -s 500 -t 2500
+MOCHA_FLAGS = --ui tdd --reporter spec -s 500 -t 5000
 ifdef OPTS
 	MOCHA_FLAGS += $(OPTS)
 endif

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -1,0 +1,23 @@
+/*jslint node: true */
+'use strict';
+
+var Promise = require('bluebird');
+
+var settings = require('../../settings');
+
+// Default to a no-cache strategy.
+var strategy = {
+  get: function get() {
+    return Promise.resolve(null);
+  },
+  save: function save() {
+    return Promise.resolve(undefined);
+  }
+};
+
+if (settings.cache === 'mongo') {
+  strategy = require('./mongo');
+}
+
+exports.get = strategy.get;
+exports.save = strategy.save;

--- a/lib/cache/mongo.js
+++ b/lib/cache/mongo.js
@@ -1,0 +1,50 @@
+/*jslint node: true */
+'use strict';
+
+var Promise = require('bluebird');
+
+var CacheItem = require('../models/CacheItem');
+var settings = require('../../settings');
+
+var CACHE_NAME_PREFIX = 'api-cache-' + settings.name + '-';
+
+Promise.promisifyAll(CacheItem);
+
+exports.get = function get(cache, name) {
+  return CacheItem.findOneAndUpdateAsync({
+    _id: {
+      cache: CACHE_NAME_PREFIX + cache,
+      key: name
+    }
+  }, {
+    $set: {
+      accessed: new Date()
+    }
+  }).then(function (doc) {
+    if (!doc) {
+      return null;
+    }
+    return doc.contents;
+  });
+};
+
+exports.save = function save(cache, name, contents) {
+  // Wrap in a Promise.try, so that any potential synchronous Mongoose
+  // exceptions get funneled into the promise.
+  return Promise.try(function () {
+    return CacheItem.findOneAndUpdateAsync({
+      _id: {
+        cache: CACHE_NAME_PREFIX + cache,
+        key: name
+      }
+    }, {
+      $set: {
+        accessed: new Date(),
+        contents: contents
+      }
+    }, {
+      upsert: true,
+      select: { _id: 1 }
+    });
+  });
+};

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -2,18 +2,18 @@
 'use strict';
 
 var _ = require('lodash');
+var logfmt = require('logfmt');
 var moment = require('moment-range');
 var Promise = require('bluebird');
-
-// LocalData
-var settings = require('../../settings');
-
 
 // Models
 var Response = require('../models/Response');
 var Survey = require('../models/Survey');
 
+var cache = require('../cache');
+
 Promise.promisifyAll(Survey);
+Promise.promisifyAll(Response);
 Promise.promisifyAll(Response.collection);
 
 var MAX_ENTRIES = 250;
@@ -131,45 +131,133 @@ exports.stats = function stats(req, res) {
     }
   }
 
-  Response.collection.groupAsync({}, conditions, {
-    stats: { Collectors: {} },
-    count: 0
-  }, reduce)
-  .then(function (doc) {
-    if (!doc || doc.length === 0) {
-      // Make sure the survey exists. We don't check beforehand because it
-      // saves a query in the most common case.
-      return Promise.resolve(Survey.findOne({
-        id: surveyId
-      })
-      .lean()
-      .exec()).then(function (survey) {
-        if (survey === null) {
-          res.send(404);
-        } else {
-          res.send({
-            stats: { Collectors: {} }
-          });
-        }
+  var cacheKey = JSON.stringify(conditions);
+  cache.get('stats', cacheKey)
+  .then(function (contents) {
+    if (!contents) {
+      logfmt.log({
+        at: 'stats_cache',
+        event: 'miss',
+        reason: 'no_entry'
       });
+      return;
     }
 
-    var stats = doc[0].stats;
-    var count = doc[0].count;
-    // Calculate "no response" count for each question
-    _.forEach(_.keys(stats), function (key) {
-      var stat = stats[key];
-      var sum = _.reduce(stat, summer, 0);
-      var remainder = count - sum;
+    var count = contents.count || 0;
+    var modified = contents.modified || (new Date(0));
+    var modificationQuery = _.defaults({
+      'entries.modified': {
+        $gt: modified
+      }
+    }, conditions);
 
-      stats[key]['no response'] = remainder;
+    return Promise.join(
+      Response.countAsync(conditions),
+      Promise.resolve(
+        Response.findOne(modificationQuery)
+        .select({ _id: 1 })
+        .lean()
+        .exec()
+      ).then(function (doc) {
+        return !!doc;
+      })
+    ).spread(function (trueCount, hasNew) {
+      if (hasNew) {
+        logfmt.log({
+          at: 'stats_cache',
+          event: 'miss',
+          reason: 'new_data',
+          old_modified: modified.toISOString()
+        });
+        return;
+      }
+      if (trueCount !== count) {
+        logfmt.log({
+          at: 'stats_cache',
+          event: 'miss',
+          reason: 'count_mismatch',
+          old_count: count,
+          new_count: trueCount
+        });
+        return;
+      }
+
+      logfmt.log({
+          at: 'stats_cache',
+          event: 'hit'
+      });
+      return contents.data;
     });
+  }).then(function (stats) {
+    if (stats) {
+      return stats;
+    }
+
+    return Response.collection.groupAsync({}, conditions, {
+      stats: { Collectors: {} },
+      count: 0
+    }, reduce)
+    .then(function (doc) {
+      if (!doc || doc.length === 0) {
+        // Make sure the survey exists. We don't check beforehand because it
+        // saves a query in the most common case.
+        return Promise.resolve(Survey.findOne({
+          id: surveyId
+        })
+        .lean()
+        .exec()).then(function (survey) {
+          if (survey === null) {
+            return;
+          }
+
+          var stats = { Collectors: {} };
+          return cache.save('stats', cacheKey, {
+            modified: new Date(),
+            count: 0,
+            data: stats
+          }).then(function () {
+            return stats;
+          });
+        });
+      }
+
+      var stats = doc[0].stats;
+      var count = doc[0].count;
+      // Calculate "no response" count for each question
+      _.forEach(_.keys(stats), function (key) {
+        var stat = stats[key];
+        var sum = _.reduce(stat, summer, 0);
+        var remainder = count - sum;
+
+        stats[key]['no response'] = remainder;
+      });
+
+      var modified = new Date();
+      return cache.save('stats', cacheKey, {
+        modified: modified,
+        count: count,
+        data: stats
+      }).then(function () {
+        logfmt.log({
+          at: 'stats_cache',
+          event: 'save',
+          modified: modified.toISOString(),
+          count: count
+        });
+        return stats;
+      });
+    });
+  }).then(function (stats)  {
+    if (!stats) {
+      res.send(404);
+      return;
+    }
 
     res.send({
       stats: stats
     });
   }).catch(function (error) {
-    console.log(error);
+    logfmt.error(error);
     res.send(500);
   });
 };

--- a/lib/models/CacheItem.js
+++ b/lib/models/CacheItem.js
@@ -1,0 +1,20 @@
+/*jslint node: true */
+'use strict';
+
+var mongoose = require('mongoose');
+
+var cacheItemSchema = new mongoose.Schema({
+  _id: {
+    cache: String,
+    key: String
+  },
+  accessed: {
+    type: Date,
+    expires: '7d'
+  },
+  contents: {}
+}, {
+  _id: false
+});
+
+module.exports = mongoose.model('CacheItem', cacheItemSchema, 'cacheItems');

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -5,7 +5,7 @@
  * ==================================================
  * Mongoose MongoDB connection
  * ==================================================
- * 
+ *
  */
 
 var mongoose = require('mongoose');
@@ -28,22 +28,13 @@ exports.connect = function connect(done) {
     }
   };
 
-  mongoose.connect(settings.mongo, opts);
+  mongoose.connect(settings.mongo, opts, done);
 
   db = mongoose.connection;
-
-  db.on('error', function (error) {
-    console.log('Error connecting to MongoDB server:');
-    console.log(error);
-    console.log(error.stack);
-    throw error;
-  });
 
   db.on('reconnected', function () {
     console.log('We have reconnected to the MongoDB server.');
   });
-
-  db.once('open', done);
 
   return db;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,8 +10,8 @@ var http = require('http');
 var _ = require('lodash');
 var async = require('async');
 var express = require('express');
+var logfmt = require('logfmt');
 var MongoStore = require('connect-mongo')(express);
-var uuid = require('node-uuid');
 var s3 = require('connect-s3');
 var passport = require('passport');
 
@@ -20,147 +20,87 @@ var settings = require('../settings');
 var routes = require('./routes');
 var postgres = require('./postgres');
 var tasks = require('./tasks');
+var util = require('./util');
 
 // Basic app variables
 var server;
-var app = express();
 var db = null;
 
-// ID generator
-var idgen = uuid.v1;
+function createApp(db) {
+  var app = express();
 
-// Log some information when requests are first received.
-if (process.env.REQUEST_LOGGER) {
-  app.use(express.logger({
-    immediate: true,
-    format: process.env.REQUEST_LOGGER
-  }));
-}
+  // Log some information when requests are first received.
+  if (process.env.REQUEST_LOGGER) {
+    app.use(express.logger({
+      immediate: true,
+      format: process.env.REQUEST_LOGGER
+    }));
+  }
 
-// Specify logging through an environment variable, so we can log differently
-// locally, on dev/test Heroku apps, and on production Heroku apps.
-if (process.env.EXPRESS_LOGGER) {
-  app.use(express.logger(process.env.EXPRESS_LOGGER));
-}
+  // Specify logging through an environment variable, so we can log differently
+  // locally, on dev/test Heroku apps, and on production Heroku apps.
+  if (process.env.EXPRESS_LOGGER) {
+    app.use(express.logger(process.env.EXPRESS_LOGGER));
+  }
 
-// Have Express wrap the response in a function for JSONP requests
-// https://github.com/visionmedia/express/issues/664
-app.set('jsonp callback', true);
+  // Have Express wrap the response in a function for JSONP requests
+  // https://github.com/visionmedia/express/issues/664
+  app.set('jsonp callback', true);
 
-// Use a compact JSON representation
-app.set('json spaces', 0);
+  // Use a compact JSON representation
+  app.set('json spaces', 0);
 
-// Allow Heroku to handle SSL for us
-app.enable('trust proxy');
+  // Allow Heroku to handle SSL for us
+  app.enable('trust proxy');
 
-// Allows clients to simulate DELETE and PUT
-// (some clients don't support those verbs)
-// http://stackoverflow.com/questions/8378338/what-does-connect-js-methodoverride-do
-app.use(express.methodOverride());
+  // Allows clients to simulate DELETE and PUT
+  // (some clients don't support those verbs)
+  // http://stackoverflow.com/questions/8378338/what-does-connect-js-methodoverride-do
+  app.use(express.methodOverride());
 
-// IE 8 and 9 can't post application/json for cross-origin requests, so we
-// accept text/plain treat it as JSON.
-// TODO: if we need to accept text/plain in the future, then we need to adjust
-// this
-function textParser(req, res, next) {
-  if (req._body) { return next(); }
-  req.body = req.body || {};
+  // Skip parsing the body for requests that we'll proxy to the tileserver
+  app.use('/tiles', util.rawParser);
 
-  // For GET/HEAD, there's no body to parse.
-  if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
+  // Actually have Express parse text/plain as JSON
+  app.use(util.textParser);
 
-  // Check for text/plain content type
-  var type = req.headers['content-type'];
-  if (type === undefined || 'text/plain' !== type.split(';')[0]) { return next(); }
+  // Default to text/plain if no content-type was provided.
+  app.use(function(req, res, next) {
+    if (req.body) { return next(); }
+    if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
 
-  // Flag as parsed
-  req._body = true;
-
-  console.log('info at=text_parser event=received_text/plain');
-
-  // Parse text/plain as if it was JSON
-  var buf = '';
-  req.setEncoding('utf8');
-  req.on('data', function(chunk){
-    buf += chunk;
-  });
-  req.on('end', function(){
-    try {
-      if (!buf.length) {
-        req.body = {};
-      } else {
-        req.body = JSON.parse(buf);
-      }
+    if (!req.headers['content-type']) {
+      req.body = {};
+      util.textParser(req, res, next);
+    } else {
       next();
-    } catch (err) {
-      err.status = 400;
-      next(err);
     }
   });
-}
 
-function rawParser(req, res, next) {
-  if (req._body) { return next(); }
-  req.body = req.body || {};
+  app.use(express.json());
+  app.use(express.urlencoded());
 
-  // For GET/HEAD, there's no body to parse.
-  if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
+  // Keep extensions, so we can properly guess MIME types later.
+  // TODO: We should get the MIME type from the upload headers.
+  app.use(express.multipart({
+    keepExtensions: true
+  }));
 
-  // Flag as parsed
-  req._body = true;
+  // Let's compress everything!
+  app.use(express.compress());
 
-  var bufs = [];
-  var len = 0;
-  req.on('data', function(chunk){
-    bufs.push(chunk);
-    len += chunk.length;
-  });
-  req.on('end', function(){
-    req.body = Buffer.concat(bufs, len);
+  // Add common headers
+  app.use(function(req, res, next) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Mime-Type, X-Requested-With, X-File-Name, Content-Type");
+    res.header('Cache-Control', 'max-age=0, must-revalidate');
     next();
   });
+
+  return app;
 }
 
-// Skip parsing the body for requests that we'll proxy to the tileserver
-app.use('/tiles', rawParser);
-
-// Actually have Express parse text/plain as JSON
-app.use(textParser);
-
-// Default to text/plain if no content-type was provided.
-app.use(function(req, res, next) {
-  if (req.body) { return next(); }
-  if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
-
-  if (!req.headers['content-type']) {
-    req.body = {};
-    textParser(req, res, next);
-  } else {
-    next();
-  }
-});
-
-app.use(express.json());
-app.use(express.urlencoded());
-
-// Keep extensions, so we can properly guess MIME types later.
-// TODO: We should get the MIME type from the upload headers.
-app.use(express.multipart({
-  keepExtensions: true
-}));
-
-// Let's compress everything!
-app.use(express.compress());
-
-// Add common headers
-app.use(function(req, res, next) {
-  res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Headers", "Origin, X-Mime-Type, X-Requested-With, X-File-Name, Content-Type");
-  res.header('Cache-Control', 'max-age=0, must-revalidate');
-  next();
-});
-
-function setupAuth(db) {
+function setupAuth(app, db) {
   // Authentication-related middleware
   app.use(express.cookieParser());
 
@@ -187,7 +127,7 @@ function setupAuth(db) {
   app.set('session-middleware', session);
 }
 
-function setupRoutes() {
+function setupRoutes(app) {
   routes.setup(app);
 
   // Serve the mobile collection app from /mobile
@@ -226,7 +166,7 @@ function setupRoutes() {
 
 // We're done with our preflight stuff.
 // Now, we start listening for requests.
-function startServer(port, cb) {
+function startServer(app, port, cb) {
   server = http.createServer(app);
   server.listen(port, function (err) {
     console.log('info at=server event=listening port=' + port);
@@ -253,12 +193,21 @@ function run(cb) {
       cb = function () {};
     }
 
-    db = mongo.connect(function () {
-      setupAuth(db);
-      setupRoutes(); // Needs to happen AFTER setupAuth
+    db = mongo.connect(function (error) {
+      if (error) {
+        logfmt.error(error);
+        cb(error);
+        return;
+      }
+
+      logfmt.log({ level: 'info', at: 'server', event: 'mongo_connected' });
+
+      var app = createApp(db);
+      setupAuth(app, db);
+      setupRoutes(app); // Needs to happen AFTER setupAuth
       async.series([
         tasks.connect,
-        startServer.bind(null, settings.port)
+        startServer.bind(null, app, settings.port)
       ], cb);
     });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -288,3 +288,66 @@ util.simplifyCoordinates = (function () {
 
   return simplify;
 }());
+
+// IE 8 and 9 can't post application/json for cross-origin requests, so we
+// accept text/plain treat it as JSON.
+// TODO: if we need to accept text/plain in the future, then we need to adjust
+// this
+util.textParser = function textParser(req, res, next) {
+  if (req._body) { return next(); }
+  req.body = req.body || {};
+
+  // For GET/HEAD, there's no body to parse.
+  if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
+
+  // Check for text/plain content type
+  var type = req.headers['content-type'];
+  if (type === undefined || 'text/plain' !== type.split(';')[0]) { return next(); }
+
+  // Flag as parsed
+  req._body = true;
+
+  console.log('info at=text_parser event=received_text/plain');
+
+  // Parse text/plain as if it was JSON
+  var buf = '';
+  req.setEncoding('utf8');
+  req.on('data', function(chunk){
+    buf += chunk;
+  });
+  req.on('end', function(){
+    try {
+      if (!buf.length) {
+        req.body = {};
+      } else {
+        req.body = JSON.parse(buf);
+      }
+      next();
+    } catch (err) {
+      err.status = 400;
+      next(err);
+    }
+  });
+};
+
+util.rawParser = function rawParser(req, res, next) {
+  if (req._body) { return next(); }
+  req.body = req.body || {};
+
+  // For GET/HEAD, there's no body to parse.
+  if ('GET' === req.method || 'HEAD' === req.method) { return next(); }
+
+  // Flag as parsed
+  req._body = true;
+
+  var bufs = [];
+  var len = 0;
+  req.on('data', function(chunk){
+    bufs.push(chunk);
+    len += chunk.length;
+  });
+  req.on('end', function(){
+    req.body = Buffer.concat(bufs, len);
+    next();
+  });
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "3.0.x",
     "knox": "~0.9.1",
     "lodash": "~1.0.1",
+    "logfmt": "^1.2.0",
     "lru-cache": "2.2.2",
     "moment": "2.8.x",
     "moment-range": "1.0.x",

--- a/settings.js
+++ b/settings.js
@@ -39,6 +39,9 @@ settings.psqlConnectionString = process.env.DATABASE_URL;
 // Tiles
 settings.tilePrefix = process.env.TILESERVER_BASE;
 
+// Cache (mongo, redis, none)
+settings.cache = process.env.CACHE;
+
 // Static apps
 settings.mobilePrefix = process.env.REMOTE_MOBILE_PREFIX;
 settings.adminPrefix = process.env.REMOTE_ADMIN_PREFIX;
@@ -61,4 +64,3 @@ settings.port = process.env.PORT || 3000;
 settings.testSecurePort = 3838;
 
 settings.NOANSWER = 'no response';
-

--- a/test/compress.js
+++ b/test/compress.js
@@ -1,15 +1,12 @@
 /*jslint node: true, indent: 2, white: true, vars: true */
-/*globals suite, test, setup, suiteSetup, suiteTeardown, done, teardown */
+/*globals suite, test, setup, suiteSetup, suiteTeardown */
 'use strict';
 
 var server = require('./lib/router');
-var assert = require('assert');
-var util = require('util');
 var request = require('request');
 var should = require('should');
 
 var settings = require('../settings.js');
-var User = require('../lib/models/User');
 
 var fixtures = require('./data/fixtures');
 
@@ -22,8 +19,8 @@ suite('Compress', function () {
     server.run(done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   setup(function (done) {
@@ -35,8 +32,6 @@ suite('Compress', function () {
   });
 
   suite('GET', function () {
-    var id;
-
     test('Requesting data', function (done) {
       request.get({
         url: BASEURL + '/surveys',
@@ -54,4 +49,3 @@ suite('Compress', function () {
     });
   });
 });
-

--- a/test/data/fixtures.js
+++ b/test/data/fixtures.js
@@ -222,6 +222,9 @@ fixtures.makeResponses = function makeResponses(count, options) {
 
   var data = { responses: [] };
   var parcelBase = 123456;
+  if (options && options.parcelBase) {
+    parcelBase = options.parcelBase;
+  }
   var i;
   for (i = 0; i < count; i += 1) {
     var num = parcelBase + i;

--- a/test/export.js
+++ b/test/export.js
@@ -54,8 +54,8 @@ suite('Exports', function () {
     ], done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   test('Shapefile', function (done) {

--- a/test/features.js
+++ b/test/features.js
@@ -1,12 +1,10 @@
 /*jslint node: true */
-/*globals suite, test, setup, suiteSetup, suiteTeardown, done, teardown */
+/*globals suite, test, setup, suiteSetup, suiteTeardown  */
 'use strict';
 
 /*
  * Tests for the base geographic features API.
  */
-
-var util = require('util');
 
 var _ = require('lodash');
 var async = require('async');
@@ -88,8 +86,8 @@ suite('Features', function () {
     server.run(done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   test('Get a parcel by id', function (done) {

--- a/test/forms.js
+++ b/test/forms.js
@@ -73,8 +73,8 @@ suite('Forms', function () {
     ], done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   suite('GET', function () {

--- a/test/orgs.js
+++ b/test/orgs.js
@@ -64,8 +64,8 @@ suite('Orgs', function () {
     ], done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
 

--- a/test/parcels.js
+++ b/test/parcels.js
@@ -65,8 +65,8 @@ suite('Parcels', function () {
     server.run(done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   suite('GET', function () {
@@ -249,4 +249,3 @@ suite('Parcels', function () {
 
   });
 });
-

--- a/test/responses.js
+++ b/test/responses.js
@@ -41,8 +41,8 @@ suite('Responses', function () {
     });
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   suite('POST', function () {

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -24,8 +24,8 @@ suite('Sessions', function () {
     server.run(done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   test('Sessions should persist across server restart', function (done) {

--- a/test/slugs.js
+++ b/test/slugs.js
@@ -37,8 +37,8 @@ suite('Slugs', function () {
     server.run(done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   var jar;

--- a/test/static.js
+++ b/test/static.js
@@ -22,8 +22,8 @@ suite('Static', function () {
     server.run(done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   suite('Mobile client', function () {

--- a/test/surveys.js
+++ b/test/surveys.js
@@ -114,8 +114,8 @@ suite('Surveys', function () {
     ], done);
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   suite("Utilities:", function() {

--- a/test/users.js
+++ b/test/users.js
@@ -73,8 +73,8 @@ suite('Users -', function () {
     });
   });
 
-  suiteTeardown(function () {
-    server.stop();
+  suiteTeardown(function (done) {
+    server.stop(done);
   });
 
   suite('finding, creating and editing without the API:', function () {


### PR DESCRIPTION
Use a mongo strategy. The main stats route is currently our most time-consuming by far.

Next steps: implement a redis strategy, cache other expensive calculations.

/cc @hampelm 
