### PR TITLE
Replace the entire cached document

### DIFF
--- a/lib/cache/mongo.js
+++ b/lib/cache/mongo.js
@@ -9,6 +9,7 @@ var settings = require('../../settings');
 var CACHE_NAME_PREFIX = 'api-cache-' + settings.name + '-';
 
 Promise.promisifyAll(CacheItem);
+Promise.promisifyAll(CacheItem.collection);
 
 exports.get = function get(cache, name) {
   return CacheItem.findOneAndUpdateAsync({
@@ -32,19 +33,22 @@ exports.save = function save(cache, name, contents) {
   // Wrap in a Promise.try, so that any potential synchronous Mongoose
   // exceptions get funneled into the promise.
   return Promise.try(function () {
-    return CacheItem.findOneAndUpdateAsync({
+    return CacheItem.collection.findAndModifyAsync({
       _id: {
         cache: CACHE_NAME_PREFIX + cache,
         key: name
       }
+    }, [
+      ['_id', 1]
+    ], {
+      _id: {
+        cache: CACHE_NAME_PREFIX + cache,
+        key: name
+      },
+      accessed: new Date(),
+      contents: contents
     }, {
-      $set: {
-        accessed: new Date(),
-        contents: contents
-      }
-    }, {
-      upsert: true,
-      select: { _id: 1 }
+      upsert: true
     });
   });
 };

--- a/settings.js
+++ b/settings.js
@@ -42,6 +42,9 @@ settings.tilePrefix = process.env.TILESERVER_BASE;
 // Cache (mongo, redis, none)
 settings.cache = process.env.CACHE;
 
+// Service name, used by the cache and by New Relic
+settings.name = process.env.NAME || 'unknown';
+
 // Static apps
 settings.mobilePrefix = process.env.REMOTE_MOBILE_PREFIX;
 settings.adminPrefix = process.env.REMOTE_ADMIN_PREFIX;

--- a/test/data/fixtures.js
+++ b/test/data/fixtures.js
@@ -206,7 +206,8 @@ fixtures.makeResponses = function makeResponses(count, options) {
         'use-count': '1',
         collector: 'Some Name',
         site: 'parking-lot',
-        'condition-1': 'demolish'
+        'condition-1': 'demolish',
+        'text-question': 'St. Cloud, MN; basically anything'
       }
     };
 


### PR DESCRIPTION
Bypass Mongoose’s safety logic, which reformats the document to a $set, which causes problems if we have awkward field names with dots or dollar signs in them. We're in that situation with stats because we use response values, which can include free-form text, as the stats keys.
 
/cc @hampelm 
