### PR TITLE
Use a geo intersection to validate global cached stats

### DIFF
--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -151,7 +151,24 @@ exports.stats = function stats(req, res) {
       'entries.modified': {
         $gt: modified
       }
-    }, conditions);
+    }, conditions, {
+      indexedGeometry: {
+        $geoIntersects: {
+          $geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [ -179, -85 ],
+                [ -179, 85 ],
+                [ -1, 85 ],
+                [ -1, -85 ],
+                [ -179, -85 ]
+              ]
+            ]
+          }
+        }
+      }
+    });
 
     // We use dot-notation rather than a nested document because we don't want
     // the query to consider the order of keys within the properties.survey


### PR DESCRIPTION
This is a workaround, since we don't currently have an index on `{'properties.survey': 1, 'entries.modified': 1}`, we only have one with a geo key in between those two. We should evaluate the cost of another index or look into different validation schemes for non-geo-restricted stats.

/cc @hampelm 