### PR TITLE
Improve index usage

### DIFF
--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -170,12 +170,22 @@ exports.stats = function stats(req, res) {
       }
     });
 
-    // We use dot-notation rather than a nested document because we don't want
-    // the query to consider the order of keys within the properties.survey
-    // subdoc.
+    // Use an $or because we don't want the query to consider the order of keys
+    // within the properties.survey subdoc, mostly because key order is not
+    // well-defined in JavaScript, so it's difficult to ensure a specific key
+    // order.
     var deletionQuery = _.omit(modificationQuery, 'properties.survey');
-    deletionQuery['properties.survey.deleted'] = true;
-    deletionQuery['properties.survey.id'] = modificationQuery['properties.survey'];
+    deletionQuery.$or = [{
+      'properties.survey': {
+        deleted: true,
+        id: modificationQuery['properties.survey']
+      }
+    }, {
+      'properties.survey': {
+        id: modificationQuery['properties.survey'],
+        deleted: true
+      }
+    }];
 
     return Promise.join(
       Promise.resolve(

--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -151,24 +151,7 @@ exports.stats = function stats(req, res) {
       'entries.modified': {
         $gt: modified
       }
-    }, conditions, {
-      indexedGeometry: {
-        $geoIntersects: {
-          $geometry: {
-            type: 'Polygon',
-            coordinates: [
-              [
-                [ -179, -85 ],
-                [ -179, 85 ],
-                [ -1, 85 ],
-                [ -1, -85 ],
-                [ -179, -85 ]
-              ]
-            ]
-          }
-        }
-      }
-    });
+    }, conditions);
 
     // Use an $or because we don't want the query to consider the order of keys
     // within the properties.survey subdoc, mostly because key order is not

--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -86,6 +86,13 @@ responseSchema.index({
   'entries.created': 1
 });
 
+// Index the survey ID + modification time, which we use for validating cached
+// data.
+responseSchema.index({
+  'properties.survey': 1,
+  'entries.modified': 1
+});
+
 // Index the collector name
 responseSchema.index({
   'properties.survey': 1,


### PR DESCRIPTION
Use an index-friendly query to check for deleted entries. Create and use an index on survey ID and modification time. The geo-query workaround was fragile and required a large index scan for the non-geo-restricted stats.