### PR TITLE
Use an order-independent query for updating deleted-entry containers

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -443,10 +443,17 @@ exports.del = function del(req, res) {
     var upsertZombieResponse = Promise.promisify(deleted.applyPreSave, deleted)()
     .then(function () {
       var query = {
-        'properties.survey': {
-          deleted: true,
-          id: doc.properties.survey
-        },
+        $or: [{
+          'properties.survey': {
+            deleted: true,
+            id: doc.properties.survey
+          }
+        }, {
+          'properties.survey': {
+            id: doc.properties.survey,
+            deleted: true
+          }
+        }],
         'properties.object_id': doc.properties.object_id
       };
       return Response.updateAsync(query, deleted.toUpsertDoc(), {


### PR DESCRIPTION
We don't have direct control over the key order of the `properties.survey` field when creating a zombie Response doc. So when we query for one to update/upsert, we need to check both order possibilities. The uniqueness constraint is independent of order, so we might otherwise end up creating a new doc that violates the constraint.