### PR TITLE
Handle deletion of entries with null or empty responses hashes

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -427,6 +427,11 @@ exports.del = function del(req, res) {
 
     // Take only the relevant entry data and place it in a zombie document.
     var entry = doc.entries.id(req.params.responseId);
+    // If there are old entries with null responses hashes, coerce them into a
+    // valid structure.
+    if (!entry.responses) {
+      entry.responses = {};
+    }
     var deleted = new Response({
       properties: _.defaults({
         survey: {

--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -25,6 +25,8 @@ var entrySchema = new mongoose.Schema({
     type: Object,
     validate: validateResponses
   }
+}, {
+  minimize: false
 });
 
 entrySchema.set('toObject', {


### PR DESCRIPTION
We should also migrate existing data to have empty hashes instead of null values.