### PR TITLE
Use a bbox polygon for the indexed geometry

### DIFF
--- a/lib/models/Response.js
+++ b/lib/models/Response.js
@@ -4,7 +4,7 @@
 var _ = require('lodash');
 var async = require('async');
 var mongoose = require('mongoose');
-var sweepline = require('../sweepline');
+var turf = require('turf');
 var util = require('../util');
 
 function validateResponses (val) {
@@ -192,50 +192,6 @@ responseSchema.pre('save', function parseCentroid(next) {
   next();
 });
 
-function getSingle(geometry) {
-  // If MongoDB knows how to work with this geometry, then our job is easy.
-  var type = geometry.type;
-  if (type === 'Polygon' ||
-      type === 'LineString' ||
-      type === 'Point') {
-    return geometry;
-  }
-
-  var geom;
-  if (type === 'GeometryCollection') {
-    // For GeometryCollections, we just index the first geometry, or a
-    // simplified version of that if its a Multi* geometry.
-    // This is similar to what we do right now with MultiPolygon/etc.
-    geom = geometry.geometries[0];
-
-    if (geom.type === 'Polygon' ||
-        geom.type === 'LineString' ||
-        geom.type === 'Point') {
-      return geom;
-    }
-  } else {
-    geom = geometry;
-  }
-
-  var newType;
-  switch (geometry.type) {
-    case 'MultiPoint':
-      newType = 'Point';
-      break;
-    case 'MultiLineString':
-      newType = 'LineString';
-      break;
-    case 'MultiPolygon':
-      newType = 'Polygon';
-      break;
-  }
-
-  return {
-    type: newType,
-    coordinates: geom.coordinates[0]
-  };
-}
-
 // For each string of coordinates, remove repeats.
 // Apply the util.simplify algorithm, too, to get rid of troublesome points
 // that have caused self-intersecting geometries through rounding errors.
@@ -254,7 +210,15 @@ function simplifyLineString(coordinates) {
 }
 
 function createIndexedGeometry(geometry) {
-  var geom = getSingle(geometry);
+  var geom = {
+    type: geometry.type,
+    coordinates: geometry.coordinates
+  };
+
+  if (geom.type === 'GeometryCollection') {
+    // For GeometryCollections, we just use the first geometry.
+    geom = geom.geometries[0];
+  }
 
   // For Point, we don't need to do anything.
   if (geom.type === 'LineString') {
@@ -262,35 +226,28 @@ function createIndexedGeometry(geometry) {
       geom = util.simplifyCoordinates(geom, 1E-5);
     }
     geom.coordinates = simplifyLineString(geom.coordinates);
-  } else if (geom.type === 'Polygon') {
-    // Polygon
-    // We only index the outer shell. We ignore the holes.
-    geom.coordinates = geom.coordinates.slice(0,1);
-    if (!sweepline.isSimplePolygon(geom)) {
-      console.log('warning at=response_schema issue=complex-geometry');
-      if (geom.coordinates[0].length > 5) {
-        console.log('warning at=response_schema event=simplifying-geometry');
-        geom = util.simplifyCoordinates(geom, 1E-5);
-      }
-      geom = util.rearrangeCoordinates(geom);
-    } else if (geom.coordinates[0].length > 50) {
-      geom = util.simplifyCoordinates(geom, 1E-5);
-    }
+  } else if (geom.type === 'Polygon' ||
+             geom.type === 'MultiPolygon' ||
+             geom.type === 'MultiLineString' ||
+             geom.type === 'MultiPoint') {
+    // For polygons and multi-geometries, we index a polygon made from the
+    // bounding box of the geometry. This helps avoid issues with bad polygons
+    // (repeated points, zero-area pieces, crossovers, etc.), and it avoids
+    // performance issues with super-complicated geometries (100s or over 1000
+    // coordinates).
+    var tmp = {
+      type: 'Feature',
+      geometry: geom
+    };
 
-    // Remove repeated coordinates from the polygon's ring.
-    geom.coordinates = [simplifyLineString(geom.coordinates[0])];
+    var envelope = turf.envelope(tmp);
 
-    if (geom.coordinates[0].length < 4) {
-      // If there are few coordinates and the polygon is not simple, then we
-      // might still have a degenerate polygon. Just index one of the points,
-      // so we definitely have a valid geometry.
-      // We may have arrived here after trying to simplify a complex polygon.
-      // If so, we've likely oversimplified to a degenerate polygon.
-      // TODO: Improve handling of invalid or self-intersecting polygons.
-      geom = {
-        type: 'Point',
-        coordinates: geom.coordinates[0][0]
-      };
+    // If the bounding box has an area of 0, then we have a degenerate polygon
+    // and need to fall back to indexing a single point.
+    if (turf.area(envelope) === 0) {
+      geom = turf.centroid(tmp).geometry;
+    } else {
+      geom = envelope.geometry;
     }
   }
   return geom;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "pg": "~2.8.2",
     "redis": "^0.10.1",
     "request": "2.21.x",
-    "slugs": "0.1.2"
+    "slugs": "0.1.2",
+    "turf": "^2.0.0"
   },
   "devDependencies": {
     "envrun": "~0.0.2",


### PR DESCRIPTION
For consideration. Useful but not ultra-thorough performance comparison of tileserver performance (both warm and cold cache) using the old method and the proposed method: http://git.io/jMf4

This should also eliminate issues with degenerate, malformed, and otherwise difficult geometries. As always, we preserve the original geometry and only use this code to created a separate geometry for indexing, which means we can change the algorithm at will and recreate the indexed field as a maintenance operation.