### PR TITLE
Avoid invalid MongoDB sub-field names when caching stats

### DIFF
--- a/lib/controllers/stats.js
+++ b/lib/controllers/stats.js
@@ -20,6 +20,65 @@ var MAX_ENTRIES = 250;
 var DAILY = 'daily';
 var MONTHLY = 'monthly';
 
+// Replace '\', '$', and '.' with their unicode escape codes.
+function encodeKey(key) {
+  return key.replace(/\\|\$|\./g, function (match) {
+    if (match === '.') {
+      return '\\u002e';
+    }
+    if (match === '\\') {
+      return '\\u005c';
+    }
+    if (match === '$') {
+      return '\\u0024';
+    }
+  });
+}
+
+// Replace the unicode escape codes for '\', '$', and '.' with the actual
+// characters.
+function decodeKey(key) {
+  return key.replace(/\\u005c|\\u0024|\\u002e/g, function (match) {
+    if (match === '\\u002e') {
+      return '.';
+    }
+    if (match === '\\u005c') {
+      return '\\';
+    }
+    if (match === '\\u0024') {
+      return '$';
+    }
+  });
+}
+
+// Encode the keys of the nested stats objects, so they are safe to use as
+// subdocuments in MongoDB. Mongo does not allow field names that start with a '$'
+// or contain a '.'. Normal questions and answers are slugified, so they result
+// in safe stat fields, but free-form text fields may contain offending
+// characters. Since we tally stats without processing the Form doc, we don't
+// know that we've encountered text responses.
+function encodeStats(stats, encoder) {
+  var ret = {};
+  var questions = Object.keys(stats);
+  
+  var encode = encoder || encodeKey;
+
+  questions.forEach(function (question) {
+    var tallies = stats[question];
+    var encodedTallies = {};
+    Object.keys(tallies).forEach(function (answer) {
+      encodedTallies[encode(answer)] = tallies[answer];
+    });
+    ret[question] = encodedTallies;
+  });
+
+  return ret;
+}
+
+function decodeStats(stats) {
+  return encodeStats(stats, decodeKey);
+}
+
 /**
  * Get statistics for a survey
  *
@@ -217,7 +276,7 @@ exports.stats = function stats(req, res) {
           at: 'stats_cache',
           event: 'hit'
       });
-      return contents.data;
+      return decodeStats(contents.data);
     });
   }).then(function (stats) {
     if (stats) {
@@ -265,13 +324,18 @@ exports.stats = function stats(req, res) {
       var modified = new Date();
       return cache.save('stats', cacheKey, {
         modified: modified,
-        data: stats
+        data: encodeStats(stats)
       }).then(function () {
         logfmt.log({
           at: 'stats_cache',
           event: 'save',
           modified: modified.toISOString()
         });
+        return stats;
+      }).catch(function (error) {
+        // If we fail to cache the stats, we can still respond properly to the
+        // client.
+        logfmt.error(error);
         return stats;
       });
     });


### PR DESCRIPTION
MongoDB does not allow field names that start with `$` or contain `.`. We can encounter these when caching the stats data, where we use survey answers as keys (with tallies as the values) and might see free-form text answers. To be safe, we escape both of those characters anywhere in the field name, along with `\`, so we can go back and forth easily.

/cc @hampelm 