### PR TITLE
Allow unsorted listing of responses

### DIFF
--- a/lib/controllers/responses.js
+++ b/lib/controllers/responses.js
@@ -209,7 +209,7 @@ exports.list = function list(req, res) {
 
   // Allow ascending or descending order according to creation time
   var sort = req.query.sort;
-  if (sort !== 'asc') {
+  if (sort !== 'asc' && sort !== 'none') {
     sort = 'desc';
   }
 
@@ -294,7 +294,9 @@ exports.list = function list(req, res) {
     query.limit(paging.count);
   }
 
-  query.sort({ 'entries.created': sort });
+  if (sort !== 'none') {
+    query.sort({ 'entries.created': sort });
+  }
 
   query
   .exec(function (error, responses) {

--- a/test/responses.js
+++ b/test/responses.js
@@ -1430,5 +1430,20 @@ suite('Responses', function () {
         done();
       });
     });
+
+    test('Get responses in arbitrary order', function () {
+      return request.getAsync({
+        url: BASEURL + '/surveys/' + surveyId + '/responses?startIndex=0&count=100&sort=none',
+        jar: false
+      }).spread(function (response, body) {
+        response.statusCode.should.equal(200);
+        response.should.be.json;
+        response.headers.should.not.have.property('set-cookie');
+
+        var parsed = JSON.parse(body);
+        parsed.should.have.property('responses');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Maintaining sort order with certain queries, such as for particular question-answer pairs, can be expensive.