### PR TITLE
Repair queries for feature sources

### DIFF
--- a/lib/controllers/features.js
+++ b/lib/controllers/features.js
@@ -360,7 +360,8 @@ exports.listSources = function listSources(req, res) {
   var lon = req.query.lon;
   var lat = req.query.lat;
 
-  if ((lat && !lon)  || (!lat && lon)) {
+  if ((lat !== undefined && lon === undefined) ||
+      (lat === undefined && lon !== undefined)) {
     res.send(400, {
       name: 'BadRequestError',
       message: 'Must specify both lon and lat arguments.'
@@ -370,20 +371,19 @@ exports.listSources = function listSources(req, res) {
 
   var queryConfig;
 
-  if (!lat && !lon) {
+  if (lat === undefined && lon === undefined) {
     // Get all of the sources
     queryConfig = {
       text: [
-        'SELECT sub.a AS name, sub.b AS type FROM (WITH RECURSIVE t(a,b) AS (',
-        'SELECT MIN(source), MIN(type) FROM features',
-        'UNION ALL',
-        'SELECT (SELECT source FROM features WHERE source > a ORDER BY source LIMIT 1),',
+        'SELECT sub.a AS name, sub.b AS type',
+        'FROM ( WITH RECURSIVE t(a,b) AS (',
+        'SELECT \'\', NULL',
+        'UNION ',
+        'SELECT',
+        '(SELECT source FROM features WHERE source > a ORDER BY source LIMIT 1),',
         '(SELECT type FROM features WHERE source > a ORDER BY source LIMIT 1)',
-        'FROM t WHERE a IS NOT NULL',
-        ')',
-        'SELECT t.a,t.b',
-        'FROM t',
-        'WHERE t.a IS NOT NULL) AS sub'
+        'FROM t WHERE a IS NOT NULL )',
+        'SELECT t.a,t.b FROM t WHERE t.b IS NOT NULL ) AS sub'
       ].join('\n'),
       name: 'featureAllSourcesQuery'
     };
@@ -391,28 +391,8 @@ exports.listSources = function listSources(req, res) {
     // Get the sources near the specified coordinate.
     queryConfig = {
       text: [
-        'SELECT sub.a AS name, sub.b as type, sub.id FROM (WITH RECURSIVE t(a,b) AS (',
-        'SELECT MIN(source), MIN(type) FROM features',
-        'UNION',
-        'SELECT (SELECT source FROM features WHERE source > a ORDER BY source LIMIT 1),',
-        '(SELECT type FROM features WHERE source > a ORDER BY source LIMIT 1)',
-        'FROM t WHERE a IS NOT NULL AND b IS NOT NULL',
-        ')',
-        'SELECT t.a,t.b, (',
-        'SELECT id',
-        'FROM features',
-        'WHERE ST_Intersects(',
-        'geom,',
-        'ST_Expand(',
-        'ST_SetSRID(ST_Point($1, $2),4326),',
-        '.07',
-        ')::geography',
-        ')',
-        'AND source = t.a',
-        'LIMIT 1',
-        ') AS id',
-        'FROM t) AS sub',
-        'WHERE sub.id IS NOT NULL'
+        'SELECT DISTINCT source AS name, type FROM features',
+        'WHERE geom && ST_Expand(ST_SetSRID(ST_Point($1, $2),4326), .07)::geography',
       ].join('\n'),
       values: [lon, lat],
       name: 'featureNearbySourcesQuery'


### PR DESCRIPTION
The query for sources near a point is not ultra-efficient, but it should yield correct results without going off the rails. If we add an index on features using `gist (geom, to_tsvector('simple'::regconfig, source))`, then the same query can be much more efficient (a GIST index on `geom` and `source`, using simple text search vector converstion to force-fit the source column into a GIST index). But we don't really make use of the endpoint that would call that query, so it's not a priority right now.

/cc @hampelm 